### PR TITLE
Add usage of atomic variables

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -28,6 +28,7 @@ ext.versions = [
 
         junit                  : '4.13.2',
         turbine                : '0.7.0',
+        stately                : '1.2.0'
 ]
 
 ext.libraries = [
@@ -41,6 +42,7 @@ ext.libraries = [
         rxJava            : "io.reactivex.rxjava2:rxjava:$versions.rxJava",
         rxAndroid         : "io.reactivex.rxjava2:rxandroid:$versions.rxAndroid",
         flMadStateMachine : "com.freeletics.mad:state-machine:0.3.0-alpha26",
+        stately           : "co.touchlab:stately-concurrency:$versions.stately",
 ]
 
 ext.compose = [

--- a/dsl/build.gradle
+++ b/dsl/build.gradle
@@ -33,6 +33,7 @@ kotlin {
             dependencies {
                 api project(":flowredux")
                 api libraries.flMadStateMachine
+                implementation libraries.stately
             }
         }
 

--- a/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
+++ b/dsl/src/commonMain/kotlin/com/freeletics/flowredux/dsl/FlowReduxStateMachine.kt
@@ -1,5 +1,7 @@
 package com.freeletics.flowredux.dsl
 
+import co.touchlab.stately.concurrency.AtomicInt
+import co.touchlab.stately.concurrency.value
 import com.freeletics.flowredux.FlowReduxLogger
 import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,8 +11,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 @FlowPreview
 @ExperimentalCoroutinesApi
@@ -24,8 +24,7 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
     private val inputActions = Channel<A>()
     private lateinit var outputState: Flow<S>
 
-    private val activeFlowCounterMutex = Mutex()
-    private var activeFlowCounter = 0
+    private val activeFlowCounter = AtomicInt(0)
 
     public constructor(initialState: S, logger: FlowReduxLogger? = null) : this(
         logger = logger,
@@ -43,14 +42,10 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
             .receiveAsFlow()
             .reduxStore(logger, initialState, specBlock)
             .onStart {
-                activeFlowCounterMutex.withLock {
-                    activeFlowCounter++
-                }
+                activeFlowCounter.incrementAndGet()
             }
             .onCompletion {
-                activeFlowCounterMutex.withLock {
-                    activeFlowCounter--
-                }
+                activeFlowCounter.decrementAndGet()
             }
     }
 
@@ -62,14 +57,12 @@ public abstract class FlowReduxStateMachine<S : Any, A : Any>(
 
     override suspend fun dispatch(action: A) {
         checkSpecBlockSet()
-        activeFlowCounterMutex.withLock {
-            if (activeFlowCounter <= 0) {
-                throw IllegalStateException(
-                    "Cannot dispatch action $action because state Flow of this " +
-                            "FlowReduxStateMachine is not collected yet. " +
-                            "Start collecting the state Flow before dispatching any action."
-                )
-            }
+        if (activeFlowCounter.value <= 0) {
+            throw IllegalStateException(
+                "Cannot dispatch action $action because state Flow of this " +
+                        "FlowReduxStateMachine is not collected yet. " +
+                        "Start collecting the state Flow before dispatching any action."
+            )
         }
         inputActions.send(action)
     }


### PR DESCRIPTION
If `activeFlowCounter` is not atomic an `InvalidMutabilityException` is thrown on iOS devices as soon as the state machine runs, i.e. a state is changed. Due to the way memory is managed there the variable in question is `frozen` and must not be mutated. Having an atomic int helps to solve this issue.